### PR TITLE
Allow for Julia project env selection in watch and compile

### DIFF
--- a/src/TypstJlyfish.jl
+++ b/src/TypstJlyfish.jl
@@ -26,16 +26,31 @@ include("query.jl")
 include("evaluation.jl")
 
 
+function _activate_jlproject(typst_file::AbstractString, jlproject::Union{AbstractString,Nothing})
+    if !isnothing(jlproject)
+        prj = if isempty(jlproject)
+            return mktempdir(prefix = "jlyfish-eval")
+        elseif !isabspath(jlproject)
+            return joinpath(dirname(typst_file), jlproject)
+        else
+            return jlproject
+        end
+        Pkg.activate(prj)
+    end
+end
+
+
 function watch(
     typst_file;
     typst_args = "",
     evaluation_file = default_output_file(typst_file),
     watch_path = typst_file,
+    jlproject::Union{AbstractString,Nothing} = "",
 )
     @assert isfile(typst_file) "`$typst_file` does not exist."
     @assert ispath(watch_path) "`$watch_path` does not exist."
 
-    Pkg.activate(mktempdir(prefix = "jlyfish-eval"))
+    _activate_jlproject(typst_file, jlproject)
 
     jlyfish_state = JlyfishState(;
         evaluation_file,
@@ -77,8 +92,9 @@ function compile(
     typst_query_args = "",
     typst_compile_args = "",
     evaluation_file = default_output_file(typst_file),
+    jlproject::Union{AbstractString,Nothing} = "",
 )
-    Pkg.activate(mktempdir(prefix = "jlyfish-eval"))
+    _activate_jlproject(typst_file, jlproject)
 
     jlyfish_state = JlyfishState(;
         evaluation_file,


### PR DESCRIPTION
This adds a `jlproject` kwarg to functions `watch` and `compile`.

This covers the following use cases:

* `jlproject = ""` (default): As before, create and activate a temporary Julia project environment, Typst-files will use `#jl-pkg(...)` to ensure required packages are installed.

* `jlproject = "."` (or some other path): Activate the given Julia project environment. If it's a relavive path, it is interpreted relative to `dirname(typst_file)`. A common usage would be to keep `Project.toml` and `Manifest.toml` together with the Typst code, for long-term reproducibility (but `TypstJlyfish` itself still lives the the Julia default env or so).

* `jlproject = nothing`: Don't activate a different Julia project, assumes that the current project already includes both `TypstJlyfish` and the Julia packages used in the Tpyst-embedded Julia code. A common usage would be to keep `Project.toml` and `Manifest.toml` together with the Typst code, for perfect long-term reproducibility.